### PR TITLE
Add global_conf.json for MultiTech with TTN channel plan

### DIFF
--- a/poly_pkt_fwd/global_conf_multitech-eu868-ttn.json
+++ b/poly_pkt_fwd/global_conf_multitech-eu868-ttn.json
@@ -1,0 +1,262 @@
+{
+"SX1301_conf": {
+        "lorawan_public": true,
+        "clksrc": 0, /* radio_0 provides clock to concentrator */
+        /* TTN EU channel plan */
+        "radio_0": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 867500000,
+            "rssi_offset": -166.0,
+            "tx_enable": true
+        },
+        "radio_1": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 868500000,
+            "rssi_offset": -166.0,
+            "tx_enable": false
+        },
+        "chan_multiSF_0": {
+            /* Lora MAC channel, 125kHz, all SF, 868.1 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -400000
+        },
+        "chan_multiSF_1": {
+            /* Lora MAC channel, 125kHz, all SF, 868.3 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -200000
+        },
+        "chan_multiSF_2": {
+            /* Lora MAC channel, 125kHz, all SF, 868.5 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 0
+        },
+        "chan_multiSF_3": {
+            /* Lora MAC channel, 125kHz, all SF, 867.1 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -400000
+        },
+        "chan_multiSF_4": {
+            /* Lora MAC channel, 125kHz, all SF, 867.3 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -200000
+        },
+        "chan_multiSF_5": {
+            /* Lora MAC channel, 125kHz, all SF, 867.5 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 0
+        },
+        "chan_multiSF_6": {
+            /* Lora MAC channel, 125kHz, all SF, 867.7 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 200000
+        },
+        "chan_multiSF_7": {
+            /* Lora MAC channel, 125kHz, all SF, 867.9 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 400000
+        },
+        "chan_Lora_std": {
+            /* Lora MAC channel, 250kHz, SF7, 868.3 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -200000,
+            "bandwidth": 250000,
+            "spread_factor": 7
+        },
+        "chan_FSK": {
+            /* FSK 50kbps channel, 868.8 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 300000,
+            "bandwidth": 150000,
+            "datarate": 50000
+        },
+        "tx_lut_0": {
+            /* TX gain table, index 0 */
+            "pa_gain": 0,
+            "mix_gain": 8,
+            "rf_power": -6,
+            "dig_gain": 0
+        },
+        "tx_lut_1": {
+            /* TX gain table, index 1 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": -3,
+            "dig_gain": 0
+        },
+        "tx_lut_2": {
+            /* TX gain table, index 2 */
+            "pa_gain": 0,
+            "mix_gain": 12,
+            "rf_power": 0,
+            "dig_gain": 0
+        },
+        "tx_lut_3": {
+            /* TX gain table, index 3 */
+            "pa_gain": 1,
+            "mix_gain": 8,
+            "rf_power": 3,
+            "dig_gain": 0
+        },
+        "tx_lut_4": {
+            /* TX gain table, index 4 */
+            "pa_gain": 1,
+            "mix_gain": 10,
+            "rf_power": 6,
+            "dig_gain": 0
+        },
+        "tx_lut_5": {
+            /* TX gain table, index 5 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 10,
+            "dig_gain": 0
+        },
+        "tx_lut_6": {
+            /* TX gain table, index 6 */
+            "pa_gain": 1,
+            "mix_gain": 13,
+            "rf_power": 11,
+            "dig_gain": 0
+        },
+        "tx_lut_7": {
+            /* TX gain table, index 7 */
+            "pa_gain": 2,
+            "mix_gain": 9,
+            "rf_power": 12,
+            "dig_gain": 0
+        },
+        "tx_lut_8": {
+            /* TX gain table, index 8 */
+            "pa_gain": 1,
+            "mix_gain": 15,
+            "rf_power": 13,
+            "dig_gain": 0
+        },
+        "tx_lut_9": {
+            /* TX gain table, index 9 */
+            "pa_gain": 2,
+            "mix_gain": 10,
+            "rf_power": 14,
+            "dig_gain": 0
+        },
+        "tx_lut_10": {
+            /* TX gain table, index 10 */
+            "pa_gain": 2,
+            "mix_gain": 11,
+            "rf_power": 16,
+            "dig_gain": 0
+        },
+        "tx_lut_11": {
+            /* TX gain table, index 11 */
+            "pa_gain": 3,
+            "mix_gain": 10,
+            "rf_power": 20,
+            "dig_gain": 0
+        },
+        "tx_lut_12": {
+            /* TX gain table, index 12 */
+            "pa_gain": 3,
+            "mix_gain": 11,
+            "rf_power": 23,
+            "dig_gain": 0
+        },
+        "tx_lut_13": {
+            /* TX gain table, index 13 */
+            "pa_gain": 3,
+            "mix_gain": 12,
+            "rf_power": 24,
+            "dig_gain": 0
+        },
+        "tx_lut_14": {
+            /* TX gain table, index 14 */
+            "pa_gain": 3,
+            "mix_gain": 13,
+            "rf_power": 25,
+            "dig_gain": 0
+        },
+        "tx_lut_15": {
+            /* TX gain table, index 15 */
+            "pa_gain": 3,
+            "mix_gain": 15,
+            "rf_power": 26,
+            "dig_gain": 0
+        }
+    },
+
+    "gateway_conf": {
+        /* change with default server address/ports, or overwrite in local_conf.json */
+        "gateway_ID": "AA555A0000000000",
+        /* Devices */
+        "gps": true,
+        "beacon": false,
+        "monitor": false,
+        "upstream": true,
+        "downstream": true,
+        "ghoststream": false,
+        "radiostream": true,
+        "statusstream": true,
+        /* node server */
+        "server_address": "127.0.0.1",
+        "serv_port_up": 1680,
+        "serv_port_down": 1681,
+        /* node servers for poly packet server (max 4) */
+        "servers":
+        [ { "server_address": "127.0.0.1",
+            "serv_port_up": 1680,
+            "serv_port_down": 1681,
+            "serv_enabled": false },
+          { /* "server_address": "iot.semtech.com", */
+            "server_address": "80.83.53.26",
+            "serv_port_up": 1680,
+            "serv_port_down": 1680,
+            "serv_enabled": true },
+          { /* "server_address": "croft.thethings.girovito.nl", */
+            "server_address": "54.229.214.112",
+            "serv_port_up" : 1700,
+            "serv_port_down" : 1700,
+            "serv_enabled": true } ],
+        /* adjust the following parameters for your network */
+        "keepalive_interval": 10,
+        "stat_interval": 30,
+        "push_timeout_ms": 100,
+        /* forward only valid packets */
+        "forward_crc_valid": true,
+        "forward_crc_error": false,
+        "forward_crc_disabled": true,
+        /* GPS configuration */
+        "gps_tty_path": "/dev/ttyAMA0",
+        "fake_gps": true,
+        "ref_latitude": 10,
+        "ref_longitude": 20,
+        "ref_altitude": -1,
+        /* Ghost configuration */
+        "ghost_address": "127.0.0.1",
+        "ghost_port": 1918,
+        /* Monitor configuration */
+        "monitor_address": "127.0.0.1",
+        "monitor_port": 2008,
+        "ssh_path": "/usr/bin/ssh",
+        "ssh_port": 22,
+        "http_port": 80,
+        "ngrok_path": "/usr/bin/ngrok",
+        "system_calls": ["df -m","free -h","uptime","who -a","uname -a"],
+        /* Platform definition, put a asterix here for the system value, max 24 chars. */
+        "platform": "*", 
+        /* Email of gateway operator, max 40 chars*/
+        "contact_email": "operator@gateway.tst", 
+        /* Public description of this device, max 64 chars */
+        "description": "Update me" 
+    }
+}


### PR DESCRIPTION
Config for Multitech with TTN default channel plan, as used on Kerlinks, Loranks, IMST's, etc.
